### PR TITLE
3.x support, and extensibility for OauthServerController

### DIFF
--- a/code/Entities/AccessTokenEntity.php
+++ b/code/Entities/AccessTokenEntity.php
@@ -69,7 +69,7 @@ class AccessTokenEntity extends \DataObject implements AccessTokenEntityInterfac
 	}
 
     public function addScope(ScopeEntityInterface $scope) {
-    	$this->ScopeEntities->push($scope);
+		$this->ScopeEntities()->push($scope);
     }
 
 	public function setScopes($scopes) {

--- a/code/Entities/AuthCodeEntity.php
+++ b/code/Entities/AuthCodeEntity.php
@@ -69,7 +69,7 @@ class AuthCodeEntity extends \DataObject implements AuthCodeEntityInterface
 	}
 
     public function addScope(ScopeEntityInterface $scope) {
-    	$this->ScopeEntities->push($scope);
+		$this->ScopeEntities()->push($scope);
     }
 
 	public function setScopes($scopes) {

--- a/code/OAuth.php
+++ b/code/OAuth.php
@@ -8,6 +8,7 @@
 
 	Use IanSimpson\Entities;
 	Use IanSimpson\Repositories;
+	use League\OAuth2\Server\Exception\OAuthServerException;
 
 	class OauthServerController extends \Controller {
 

--- a/code/OAuth.php
+++ b/code/OAuth.php
@@ -11,8 +11,7 @@
 
 	class OauthServerController extends \Controller {
 
-		private $repositories = array();
-		private $server;
+		protected $server;
 
 		private $myRequestAdapter;
 		private $myResponseAdapter;


### PR DESCRIPTION
Hi Ian!
We need 3.x compatibility and this currently has some fatal errors. Would you be ok having a 0.1 branch in your repo, or not keen on 3.x?

Also, we want to tweak the timeouts, and the easiest way to do it seems making `$server` protected, to allow extensions. Of course I can copy the entire `Oauth2.php`, but that doesn't seem elegant :-) Alternatively we could provide some more config options.

Keen to hear your thoughts.
Mateusz