### PR TITLE
Ensure credentials and redirect URI are given on client identity.

### DIFF
--- a/code/Entities/ClientEntity.php
+++ b/code/Entities/ClientEntity.php
@@ -8,6 +8,7 @@ namespace IanSimpson\OAuth2\Entities;
 
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ValidationResult;
 use SilverStripe\Security\RandomGenerator;
 use SilverStripe\SiteConfig\SiteConfig;
 
@@ -53,6 +54,23 @@ class ClientEntity extends DataObject implements ClientEntityInterface
             'columns' => ['ClientIdentifier']
         ]
     ];
+
+    public function validate()
+    {
+        $result = ValidationResult::create();
+
+        if (strlen($this->ClientIdentifier) !== 32) {
+            $result->addError('Client identifier must be a 32 character random token.');
+        }
+        if (strlen($this->ClientSecret) !== 64) {
+            $result->addError('Client secret must be a 64 character random token.');
+        }
+        if (empty(trim($this->ClientRedirectUri))) {
+            $result->addError('Client redirect URI must be given.');
+        }
+
+        return $result;
+    }
 
     public function populateDefaults()
     {

--- a/tests/ClientEntityTest.php
+++ b/tests/ClientEntityTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace IanSimpson\Tests;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\ValidationException;
+use IanSimpson\OAuth2\Entities\ClientEntity;
+
+class ClientEntityTest extends SapphireTest
+{
+    protected $usesDatabase = true;
+
+    public function testValidateFail()
+    {
+        $this->expectException(ValidationException::class);
+
+        $e = new ClientEntity();
+        $e->write();
+    }
+
+    public function testRedirectUriRequired()
+    {
+        $this->expectException(ValidationException::class);
+
+        $e = new ClientEntity();
+        $e->ClientIdentifier = '200c0e8058c40b101724c23fac8d8ad1';
+        $e->ClientSecret = 'b8ca798ab885f49e69507cbe093972bf505a05dd9e34a6fea2d0c3c699d323c4';
+        $e->write();
+    }
+
+    public function testRedirectUriWhitespace()
+    {
+        $this->expectException(ValidationException::class);
+
+        $e = new ClientEntity();
+        $e->ClientIdentifier = '200c0e8058c40b101724c23fac8d8ad1';
+        $e->ClientSecret = 'b8ca798ab885f49e69507cbe093972bf505a05dd9e34a6fea2d0c3c699d323c4';
+        $e->ClientRedirectUri = ' ';
+        $e->write();
+    }
+
+    public function testValidatePass()
+    {
+        $e = new ClientEntity();
+        $e->ClientIdentifier = '200c0e8058c40b101724c23fac8d8ad1';
+        $e->ClientSecret = 'b8ca798ab885f49e69507cbe093972bf505a05dd9e34a6fea2d0c3c699d323c4';
+        $e->ClientRedirectUri = 'http://somewhere.lan/oauth2/callback';
+        $e->write();
+    }
+}


### PR DESCRIPTION
SS4 equivalent of https://github.com/IanSimpson/ss-oauth2-server/pull/21

Ensuring redirect URI means that the redirect_uri query parameter is
validated against the client.